### PR TITLE
[TASK] extends regular expression to match TYPO3 6.x as well

### DIFF
--- a/res/cronjob_generateFingerprints.phpsh
+++ b/res/cronjob_generateFingerprints.phpsh
@@ -150,7 +150,7 @@ class FingerprintGenerator {
 	public function start() {
 		$xml = new SimpleXMLElement(file_get_contents($this->rssFeed));
 		foreach ($xml->channel->item as $item) {
-			preg_match('/(typo3_src-(4\.[0-9]+\.[0-9]+)).tar.gz/', $item->title, $matches);
+			preg_match('/(typo3_src-([46]\.[0-9]+\.[0-9]+)).tar.gz/', $item->title, $matches);
 			if (!empty($matches)) {
 				echo $item->title . chr(10);
 				$version = $matches[1];


### PR DESCRIPTION
This litte patch enables the creation of fingerprints also for TYPO3 6.x
